### PR TITLE
拡張メソッドの汎用性を高める

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 [Ll]ibrary/
 [Bb]uild/
 UnityGenerated/
+# Library should not freeze version, it should be written in README.
+/ProjectSettings/ProjectVersion.txt
 
 # ============= #
 # IDE generated #

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,0 @@
-m_EditorVersion: 2017.3.1f1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.1.0p4
+m_EditorVersion: 2017.3.1f1

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# What?
+# EventActivator
 
 * アプリケーション全体のイベント有効状態を管理するためのクラスを提供します。
 
-# Why?
+## Requirement
 
-* 個別のコンポーネント単位で管理していくと状態管理が複雑になってしまうため。
+* [UniRx](https://github.com/neuecc/unirx) ([umm版](https://github.com/umm-projects/unirx))
 
-# Install
+## Install
 
 ```shell
-$ npm install github:umm-projects/event_activator
+npm install github:umm-projects/event_activator
 ```
 
-# Usage
+## Usage
+
+### 個別の実装
 
 ```csharp
 using UnityEngine;
@@ -48,25 +50,28 @@ public class Sample : MonoBehaviour {
 * ボタンクリック時など、排他的なイベント実行を行いたい場合に `Deactivate()` メソッドを呼び出します。
 * 次画面に遷移した場合や、次のボタンが表示されるタイミングなどで `Activate()` メソッドを呼び出し、無効状態を解除します。
 
+### 一括設定
+
 ```csharp
 using UnityEngine;
-using UnityEngine.EventSystems;
-using UnityModule;
+using UnityModule; // この using がないと Extension Method が設定されません
 
-public class Sample : UIBehaviour {
-    protected override void Start() {
-        base.Start();
-        this.SetEventActivation();
+public class Sample : MonoBehaviour {
+    private void Start() {
+        this.RegisterEventActivationHandler();
     }
 }
 ```
 
-* `UnityEngine.EventSystems.UIBehaviour` を継承しているクラス向けに `SetEventActivation()` という拡張メソッドを提供しています。
-* 呼び出すと、 `OnActivateAsObservable()` と `OnDeactivateAsObservable()` を自動的に購読し、同一 GameObject にアタッチされている `UnityEngine.UI.Graphic` の `raycastTarget` のオンオフを切り替える実装を仕込みます。
+* `UnityEngine.Component` 向けに `RegisterEventActivationHandler()` という拡張メソッドを提供しています。
+* 呼び出すと、 `OnActivateAsObservable()` と `OnDeactivateAsObservable()` を自動的に購読し、同一 GameObject にアタッチされている `UnityEngine.UI.Graphic` の `raycastTarget` や `UnityEngine.Collider`, `UnityEngine.Collider2D` の `enabled` のオンオフを切り替える実装を仕込みます。
+* 第一引数に真偽値を渡すと子孫 Component を含むかどうかを変更可能です。
+  * default: `true`
+  * `false` を渡すと、自身の GameObject のみを対象とします。
 
-# License
+## License
 
-Copyright (c) 2017 Tetsuya Mori
+Copyright (c) 2017-2018 Tetsuya Mori
 
 Released under the MIT license, see [LICENSE.txt](LICENSE.txt)
 

--- a/UnityPackageManager/manifest.json
+++ b/UnityPackageManager/manifest.json
@@ -1,0 +1,4 @@
+{
+	"dependencies": {
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "@umm/unirx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@umm/unirx/-/unirx-1.0.0.tgz",
-      "integrity": "sha512-cf11iWNDmWIDZQxYnf+MyGL0wEUf29pd/dOb+YpvonuZf3+D0YNMGYY1uM3xnz/fLysPE60dBQZn3qUVqQPIKQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@umm/unirx/-/unirx-1.0.3.tgz",
+      "integrity": "sha512-da7GAcgL9eqPghx8s+Sc733KwSrTMjUQqLZUQIjlOCefBknzcI6LnNgcsnZIZsJXPsIm+sjfi712PorSLShb6A==",
       "requires": {
         "glob": "7.1.2",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@umm/singleton": "^1.0.0",
-    "@umm/unirx": "^1.0.0",
+    "@umm/unirx": "^1.0.3",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
* イベント有効無効状態の切替について、子孫ノードも辿って切り替え可能にする
  * これにより、Root Canvas などを指定して RegisterEventActivationHandler を渡せば一括制御可能になる
* 対象コンポーネントを UIBehaviour に限定せずに、Component 全てについて拡張メソッドを提供する
  * Collider 系の Component が付いている要素なども操作対象にしたかったので